### PR TITLE
[MOB-85] POST Events API - Create new event with more than maximum allowed characters on imageUrl

### DIFF
--- a/src/infrastructure/http/dtos/create-event.dto.ts
+++ b/src/infrastructure/http/dtos/create-event.dto.ts
@@ -144,7 +144,7 @@ export class CreateEventDto {
 
   @ApiPropertyOptional({ example: 'image.url', maxLength: 500 })
   @MaxLength(500, {
-    message: 'imageUrl description must have max 500 characters',
+    message: 'imageUrl must have max 500 characters',
   })
   @IsString()
   @IsOptional()

--- a/src/infrastructure/http/errors/exception-filter.ts
+++ b/src/infrastructure/http/errors/exception-filter.ts
@@ -36,20 +36,23 @@ export class HttpExceptionFilter implements ExceptionFilter {
       });
     }
 
+    // DTO scenario
     if (exception instanceof BadRequestException) {
-      if (message[0].includes('should not be empty'))
+      const firstErrorMessage = message[0];
+
+      if (firstErrorMessage.includes('should not be empty'))
         return response.status(status).json({
           ...errorResponse,
           title: 'badRequestError',
           detail: 'some inputs are missing',
-          errors: message,
+          errors: [firstErrorMessage],
         });
 
       return response.status(status).json({
         ...errorResponse,
         title: 'badRequestError',
-        detail: message[0].split(' ')[0],
-        errors: message,
+        detail: firstErrorMessage.split(' ')[0],
+        errors: [firstErrorMessage],
       });
     }
 

--- a/test/jest-unit/infrastructure/http/dtos/create-event.dto.spec.ts
+++ b/test/jest-unit/infrastructure/http/dtos/create-event.dto.spec.ts
@@ -364,7 +364,7 @@ describe('[unit-test] [CreateEventDto]', () => {
       expect(errors.length).toEqual(1);
       expect(errors[0].property).toEqual('imageUrl');
       expect(errors[0].constraints).toEqual({
-        maxLength: 'imageUrl description must have max 500 characters',
+        maxLength: 'imageUrl must have max 500 characters',
       });
     });
   });


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Title**
- [x] **[MOB US' Link](https://mobilemakers.atlassian.net/browse/MOB-85)**
- [ ] **Link PR to US**
- [ ] **Add Tests**
- [ ] **Add ENV Variables and Validations**
- [x] **[Documentation Updates](https://mobilemakers.atlassian.net/wiki/spaces/MMSOT/pages/20512795/Backend+documentation#POST-events-/v1/events)**
- [ ] **Swagger Updates**

## Testing Guide
Example curl:
```
curl --location 'http://localhost:3000/v1/events' \
--header 'Content-Type: application/json' \
--data '{
      "eventName": "MobgenFest",
      "eventDate": "2025-03-08T10:05:30.915Z",
      "description": "Hello World",
      "eventType": "Party",
      "imageUrl": "14FAFBRHz9YeFwI3xGPbyvOepcRwvZolFS1It2JycQU5A2jpEXsejzxFhhALl5E59grACeIcf8Y70WouGLSFI8BDhmQW3wYZdgVAlJnULuVsviLz68BHFpoUacqktKuaU3iy2enXupBxU5KJMS3FNKhAxoQv0GQj5sSbkvDEJm4A3ppyIQYdXOAgJAWOxQxiqGzrHEPK0rDF8lrCvJfis1zPOtd4ghRAXGaxZr0DCFqKorEFmhbY75yUwoCTvg2U5nW16uI7ALTg4j2tgEXmHqBrgVIS1PY7uR7ukZkf89NuuCpy2zTWnFWzbg3H3uGrPXb036Sh21bxP34bniqOpzxfZBr3IvoGT1qvNSS32C1T1CmiuttL5WOt9brK6INcE1rakZP3LSZgrEABgKzII4av6VoJRmNTXxGmwL5npmS0LMFyoHXWI88ueeIaSh8cl40zb5SqqYCxLlOSvdZqCSH5TI4hLoRdIjKMfKV9ahDP94jWFSuP3",
      "location": { "name": "", "lat": 43, "long": -8 },
      "tags": [ "Meal", "Music" ]
    }'
```

Documentation: ticket linked to related stories for API Post `/events`