### PR TITLE
[MOB-163] Make the verificationCode valid only once

### DIFF
--- a/.github/tmp/branch.txt
+++ b/.github/tmp/branch.txt
@@ -1,1 +1,1 @@
-feature/MOB-122
+feature/MOB-163

--- a/src/application/handler/account/activate-account.service.ts
+++ b/src/application/handler/account/activate-account.service.ts
@@ -33,7 +33,7 @@ export class ActivateAccountService {
         `[ActivateAccountService] [activate] - x-request-id: ${requestId}`,
       );
 
-      const { email } = await this.temporalCodeRepository.getCode(
+      const { id, email } = await this.temporalCodeRepository.getCode(
         verificationCode,
         TEMPORAL_CODE_TYPE.VERIFICATION,
         requestId,
@@ -66,6 +66,8 @@ export class ActivateAccountService {
         },
         { excludeExtraneousValues: true },
       );
+
+      await this.temporalCodeRepository.removeCodeById(id, requestId);
 
       return accountLoggedDto;
     } catch (error) {

--- a/src/application/handler/account/forgot-password.service.ts
+++ b/src/application/handler/account/forgot-password.service.ts
@@ -50,13 +50,7 @@ export class ForgotPasswordService {
         const { from, subject, html } =
           this.generateMailService.getForgotPasswordEmail(temporalCode);
 
-        await this.nodemailerService.sendEmail(
-          email,
-          from,
-          subject,
-          html,
-          requestId,
-        );
+        this.nodemailerService.sendEmail(email, from, subject, html, requestId);
       }
     } catch (error) {
       this.logger.error(

--- a/src/infrastructure/dtos/index.ts
+++ b/src/infrastructure/dtos/index.ts
@@ -5,3 +5,4 @@ export * from './new-pair-of-tokens.dto';
 export * from './pair-of-tokens.dto';
 export * from './user-profile.dto';
 export * from './event-participants.dto';
+export * from './temporal-code.dto';

--- a/src/infrastructure/dtos/temporal-code.dto.ts
+++ b/src/infrastructure/dtos/temporal-code.dto.ts
@@ -1,0 +1,31 @@
+import { Expose, Transform } from 'class-transformer';
+import { IsDate, IsNumber, IsString } from 'class-validator';
+
+export class TemporalCodeDto {
+  @Expose({ name: '_id' })
+  @Transform((value) => value.obj._id.toString())
+  @IsString()
+  id: string;
+
+  @Expose()
+  @IsNumber()
+  code: number;
+
+  @Expose()
+  @IsString()
+  type: string;
+
+  @Expose()
+  @IsString()
+  email: string;
+
+  @Expose()
+  @Transform(({ value }) => new Date(value))
+  @IsDate()
+  createdAt: Date;
+
+  @Expose()
+  @Transform(({ value }) => new Date(value))
+  @IsDate()
+  updatedAt: Date;
+}

--- a/test/jest-component/features/steps/account/activate-account-steps.ts
+++ b/test/jest-component/features/steps/account/activate-account-steps.ts
@@ -48,6 +48,10 @@ export const activateAccountSteps: StepDefinitions = ({ given, and }) => {
     });
 
     jest.spyOn(context.tokensRepository, 'save').mockResolvedValue(null);
+
+    jest
+      .spyOn(context.temporalCodeRepository, 'removeById')
+      .mockResolvedValue(null);
   });
 
   and('verificationCode provided expired', () => {

--- a/test/mocks/db/common.ts
+++ b/test/mocks/db/common.ts
@@ -5,3 +5,5 @@ export const EVENT_CORE_FIELDS_MOCK_DB_ID = '6656e23640e1fdb4ceb23cc7';
 export const OLD_EVENT_MOCK_DB_ID = '6656e23640e1fdb4ceb23cc8';
 
 export const USER_MOCK_DB_ID = '665f019c17331ebee550b2ff';
+
+export const TEMPORAL_CODE_DB_ID = '6686785f52eb2b68944aacbc';

--- a/test/mocks/db/temporal-code.ts
+++ b/test/mocks/db/temporal-code.ts
@@ -1,8 +1,12 @@
 import { TEMPORAL_CODE_TYPE } from '../../../src/domain/const';
 import { EMAIL_MOCK_DB } from './user';
+import { TEMPORAL_CODE_DB_ID } from './common';
 
 export const VERIFICATION_CODE_DATA_MOCK_DB = {
+  _id: TEMPORAL_CODE_DB_ID,
   code: 123456,
   type: TEMPORAL_CODE_TYPE.VERIFICATION,
   email: EMAIL_MOCK_DB,
+  createdAt: new Date(),
+  updatedAt: new Date(),
 };


### PR DESCRIPTION
## Pull Request Checklist

- [x] **Title**
- [x] **[MOB US' Link](https://mobilemakers.atlassian.net/browse/MOB-163)**
- [ ] **Link PR to US**
- [x] **Add Tests**
- [ ] **Add ENV Variables and Validations**
- [x] **[Documentation Updates](https://mobilemakers.atlassian.net/wiki/spaces/MMSOT/pages/15269917/Tokens+management)**
- [ ] **Swagger Updates**

## Testing Guide
- Register a new user
```
curl --location 'http://localhost:3000/v1/account/register' \
--header 'Content-Type: application/json' \
--data-raw '{
    "name": "Carlos",
    "lastName": "Valderrama",
    "password": "SuperSecret1!",
    "email": "ozunalocal41@yopmail.com"
}'
```
- Execute activate account flow before verificationCode expire 
```
curl --location --request PUT 'http://localhost:3000/v1/account/activate' \
--header 'Content-Type: application/json' \
--data '{
    "verificationCode": "220079"
}'
```
- Execute activate account endpoint again with same code to check the 400 error